### PR TITLE
upgrade to separate PropTypes

### DIFF
--- a/library/ViewPager.js
+++ b/library/ViewPager.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
   View,
   ListView,

--- a/library/ViewPager.js
+++ b/library/ViewPager.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {
   View,
+  ViewPropTypes,
   ListView,
   Platform
 } from 'react-native';
@@ -16,7 +17,7 @@ const MIN_FLING_VELOCITY = 0.5;
 export default class ViewPager extends Component {
 
   static propTypes = {
-    ...View.propTypes,
+    ...ViewPropTypes,
     initialPage: PropTypes.number,
     pageMargin: PropTypes.number,
     scrollEnabled: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "prop-types": "^15.6.0",
+    "react-mixin": "^3.0.5",
     "react-native-gesture-responder": "0.1.1",
     "react-native-scroller": "0.0.6",
-    "react-mixin": "^3.0.5",
     "react-timer-mixin": "^0.13.3"
   }
 }


### PR DESCRIPTION
React extracted `PropTypes` to separate module. This PR upgrades to make use of that.